### PR TITLE
allow external ips to be used for miner

### DIFF
--- a/neurons/miners/StableMiner/base.py
+++ b/neurons/miners/StableMiner/base.py
@@ -108,8 +108,7 @@ class BaseMiner(ABC):
         self.axon = (
             bt.axon(
                 wallet=self.wallet,
-                external_ip=bt.utils.networking.get_external_ip(),
-                port=self.config.axon.port,
+                config=self.config,
             )
             .attach(
                 forward_fn=self.is_alive,


### PR DESCRIPTION
allow external ips to be used for miner by specifying flag `--axon.external_ip`